### PR TITLE
Use stable version of the multipart stream builder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   "require": {
     "php": "^7.0",
     "php-http/httplug": "^1.0",
-    "php-http/multipart-stream-builder": "^0.1.4",
+    "php-http/multipart-stream-builder": "^1.0",
     "php-http/client-common": "^1.1",
     "php-http/discovery": "^1.0"
   },


### PR DESCRIPTION
There is one thing that might be considered as a BC break. If we, for whatever reason, added multiple streams/post data with the same name. Before they were overridden but since 0.2.0 we do allow duplicate values. 
