### PR TITLE
Added Update translations param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 /phpspec.yml
 /phpunit.xml
 /vendor/
+composer.phar
+/.idea/
+

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,3 @@
 /phpspec.yml
 /phpunit.xml
 /vendor/
-composer.phar
-/.idea/
-

--- a/src/Api/Upload.php
+++ b/src/Api/Upload.php
@@ -44,6 +44,7 @@ class Upload extends HttpApi
             ['name' => 'file', 'content' => file_get_contents($filename), 'filename' => basename($filename)],
             ['name' => 'file_format', 'content' => $ext],
             ['name' => 'locale_id', 'content' => $params['locale_id']],
+	        ['name' => 'update_translations', 'content' => $params['update_translations']]
         ];
 
         if (isset($params['tags'])) {

--- a/src/Api/Upload.php
+++ b/src/Api/Upload.php
@@ -44,7 +44,7 @@ class Upload extends HttpApi
             ['name' => 'file', 'content' => file_get_contents($filename), 'filename' => basename($filename)],
             ['name' => 'file_format', 'content' => $ext],
             ['name' => 'locale_id', 'content' => $params['locale_id']],
-	        ['name' => 'update_translations', 'content' => $params['update_translations']],
+            ['name' => 'update_translations', 'content' => $params['update_translations']],
         ];
 
         if (isset($params['tags'])) {

--- a/src/Api/Upload.php
+++ b/src/Api/Upload.php
@@ -44,8 +44,12 @@ class Upload extends HttpApi
             ['name' => 'file', 'content' => file_get_contents($filename), 'filename' => basename($filename)],
             ['name' => 'file_format', 'content' => $ext],
             ['name' => 'locale_id', 'content' => $params['locale_id']],
-            ['name' => 'update_translations', 'content' => $params['update_translations']],
         ];
+
+	    // Update Translations is not a mandatory API field
+	    if (isset($params['update_translations'])) {
+			$postData[] = ['name' => 'update_translations', 'content' => $params['update_translations']];
+	    }
 
         if (isset($params['tags'])) {
             $postData[] = ['name' => 'tags', 'content' => $params['tags']];

--- a/src/Api/Upload.php
+++ b/src/Api/Upload.php
@@ -46,9 +46,9 @@ class Upload extends HttpApi
             ['name' => 'locale_id', 'content' => $params['locale_id']],
         ];
 
-	    if (isset($params['update_translations'])) {
-			$postData[] = ['name' => 'update_translations', 'content' => $params['update_translations']];
-	    }
+        if (isset($params['update_translations'])) {
+            $postData[] = ['name' => 'update_translations', 'content' => $params['update_translations']];
+        }
 
         if (isset($params['tags'])) {
             $postData[] = ['name' => 'tags', 'content' => $params['tags']];

--- a/src/Api/Upload.php
+++ b/src/Api/Upload.php
@@ -44,7 +44,7 @@ class Upload extends HttpApi
             ['name' => 'file', 'content' => file_get_contents($filename), 'filename' => basename($filename)],
             ['name' => 'file_format', 'content' => $ext],
             ['name' => 'locale_id', 'content' => $params['locale_id']],
-	        ['name' => 'update_translations', 'content' => $params['update_translations']]
+	        ['name' => 'update_translations', 'content' => $params['update_translations']],
         ];
 
         if (isset($params['tags'])) {

--- a/src/Api/Upload.php
+++ b/src/Api/Upload.php
@@ -46,7 +46,6 @@ class Upload extends HttpApi
             ['name' => 'locale_id', 'content' => $params['locale_id']],
         ];
 
-	    // Update Translations is not a mandatory API field
 	    if (isset($params['update_translations'])) {
 			$postData[] = ['name' => 'update_translations', 'content' => $params['update_translations']];
 	    }


### PR DESCRIPTION
One of the options of phraseApp Upload is to update the translations as well.

This parameter was missing from the postData key, value pairs and added. We needed something like this for our own project where we were doing bulk upload of multiple files for the main locale and we need that to update the translations and trigger verification for other languages.

Apologies if this is implemented somewhere else in the library and we missed it.

ps. Do you want the request to be against a different branch?

Thanks